### PR TITLE
Correct DB password

### DIFF
--- a/worker/src/Worker/Program.cs
+++ b/worker/src/Worker/Program.cs
@@ -16,7 +16,7 @@ namespace Worker
         {
             try
             {
-                var pgsql = OpenDbConnection("Server=db;Username=postgres;");
+                var pgsql = OpenDbConnection("Server=db;Username=postgres;Password=dev0ps!");
                 var redisConn = OpenRedisConnection("redis");
                 var redis = redisConn.GetDatabase();
 


### PR DESCRIPTION
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD for the superuser. Use
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".
       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections
       without a password. This is *not* recommended. See PostgreSQL
       documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html